### PR TITLE
Update to DPDK 23.03

### DIFF
--- a/.github/workflows/go-build-lint-test.yml
+++ b/.github/workflows/go-build-lint-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: Set DPDK location
         run: |
           echo "DPDK_HOME=$GITHUB_WORKSPACE/dpdk" >> "$GITHUB_ENV"

--- a/build/go-p4pack/build.sh
+++ b/build/go-p4pack/build.sh
@@ -32,8 +32,8 @@ done
 
 readonly DEFAULT_DPDK_TAG=ghcr.io/stolsma/dpdk-base:dpdk-22.07-ubuntu-20.04
 readonly DEFAULT_IMAGE_NAME=ghcr.io/stolsma/go-p4pack
-readonly DEFAULT_GOP4PACK_VERSION=1.0rc1
-readonly DEFAULT_GOLANG_VERSION=1.18
+readonly DEFAULT_GOP4PACK_VERSION=1.0rc2
+readonly DEFAULT_GOLANG_VERSION=1.20
 
 export DPDK_TAG=${DPDK_TAG:-$DEFAULT_DPDK_TAG}
 export IMAGE_NAME=${IMAGE_NAME:-$DEFAULT_IMAGE_NAME}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolsma/go-p4pack
 
-go 1.18
+go 1.20
 
 require (
 	github.com/golang/glog v1.0.0


### PR DESCRIPTION
Update the used DPDK version to 23.03 as soon as it is released.

TODO:

- [x] Update to using Go 1.20.x
- [ ] Build DPDK 23.03 libraries in Github actions
- [ ] Implement new way of building and running spec files
- [ ] Rename dpdkswx package to p4dpdklib